### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # _TfL Tube Line Status for Python_
-[![PyPi version](https://pypip.in/version/tubestatus/badge.svg)](https://pypi.python.org/pypi/tubestatus/)
-[![PyPi downloads](https://pypip.in/download/tubestatus/badge.svg)](https://pypi.python.org/pypi/tubestatus/)
-[![Supported Python versions](https://pypip.in/py_versions/tubestatus/badge.svg)](https://pypi.python.org/pypi/tubestatus/)
-[![Development Status](https://pypip.in/status/tubestatus/badge.svg)](https://pypi.python.org/pypi/tubestatus/)
+[![PyPi version](https://img.shields.io/pypi/v/tubestatus.svg)](https://pypi.python.org/pypi/tubestatus/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/tubestatus.svg)](https://pypi.python.org/pypi/tubestatus/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/tubestatus.svg)](https://pypi.python.org/pypi/tubestatus/)
+[![Development Status](https://img.shields.io/pypi/status/tubestatus.svg)](https://pypi.python.org/pypi/tubestatus/)
 [![Build Status](https://travis-ci.org/jacobtomlinson/tube-status.svg?branch=master)](https://travis-ci.org/jacobtomlinson/tube-status)
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tubestatus))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tubestatus`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.